### PR TITLE
Fixed a bug in find_last_not_of function that takes the predicate

### DIFF
--- a/include/EASTL/algorithm.h
+++ b/include/EASTL/algorithm.h
@@ -1389,7 +1389,7 @@ namespace eastl
             while((--it1 != first1) && (eastl::find_if(first2, last2, eastl::bind1st<BinaryPredicate, value_type>(predicate, *it1)) != last2))
                 ; // Do nothing
 
-            if((it1 != first1) || (eastl::find_if(first2, last2, eastl::bind1st<BinaryPredicate, value_type>(predicate, *it1))) != last2)
+            if((it1 != first1) || (eastl::find_if(first2, last2, eastl::bind1st<BinaryPredicate, value_type>(predicate, *it1))) == last2)
                 return it1;
         }
 


### PR DESCRIPTION
algorithm.h:1392 - should have == instead of != (see the non-predicate version)
