### PR TITLE
FIX type_traits TODO

### DIFF
--- a/include/EASTL/internal/type_fundamental.h
+++ b/include/EASTL/internal/type_fundamental.h
@@ -79,38 +79,34 @@ namespace eastl
     //
     ///////////////////////////////////////////////////////////////////////
     template <typename T> struct is_integral : public false_type{};
-
-    // To do: Need to define volatile and const volatile versions of these.
-    template <> struct is_integral<unsigned char>            : public true_type{};
-    template <> struct is_integral<const unsigned char>      : public true_type{};
-    template <> struct is_integral<unsigned short>           : public true_type{};
-    template <> struct is_integral<const unsigned short>     : public true_type{};
-    template <> struct is_integral<unsigned int>             : public true_type{};
-    template <> struct is_integral<const unsigned int>       : public true_type{};
-    template <> struct is_integral<unsigned long>            : public true_type{};
-    template <> struct is_integral<const unsigned long>      : public true_type{};
-    template <> struct is_integral<unsigned long long>       : public true_type{};
-    template <> struct is_integral<const unsigned long long> : public true_type{};
-
-    template <> struct is_integral<signed char>              : public true_type{};
-    template <> struct is_integral<const signed char>        : public true_type{};
-    template <> struct is_integral<signed short>             : public true_type{};
-    template <> struct is_integral<const signed short>       : public true_type{};
-    template <> struct is_integral<signed int>               : public true_type{};
-    template <> struct is_integral<const signed int>         : public true_type{};
-    template <> struct is_integral<signed long>              : public true_type{};
-    template <> struct is_integral<const signed long>        : public true_type{};
-    template <> struct is_integral<signed long long>         : public true_type{};
-    template <> struct is_integral<const signed long long>   : public true_type{};
-
-    template <> struct is_integral<bool>            : public true_type{};
-    template <> struct is_integral<const bool>      : public true_type{};
-    template <> struct is_integral<char>            : public true_type{};
-    template <> struct is_integral<const char>      : public true_type{};
+    
+    #define EASTL_TMP_DECLARE_INTEGRAL_WITH_CV(T)\
+        template <> struct is_integral<T>                : public true_type{};\
+        template <> struct is_integral<T const>          : public true_type{};\
+        template <> struct is_integral<T volatile>       : public true_type{};\
+        template <> struct is_integral<T const volatile> : public true_type{};
+    
+    EASTL_TMP_DECLARE_INTEGRAL_WITH_CV(unsigned char)
+    EASTL_TMP_DECLARE_INTEGRAL_WITH_CV(unsigned short)
+    EASTL_TMP_DECLARE_INTEGRAL_WITH_CV(unsigned int)
+    EASTL_TMP_DECLARE_INTEGRAL_WITH_CV(unsigned long)
+    EASTL_TMP_DECLARE_INTEGRAL_WITH_CV(unsigned long long)
+    
+    EASTL_TMP_DECLARE_INTEGRAL_WITH_CV(signed char)
+    EASTL_TMP_DECLARE_INTEGRAL_WITH_CV(signed short)
+    EASTL_TMP_DECLARE_INTEGRAL_WITH_CV(signed int)
+    EASTL_TMP_DECLARE_INTEGRAL_WITH_CV(signed long)
+    EASTL_TMP_DECLARE_INTEGRAL_WITH_CV(signed long long)
+    
+    EASTL_TMP_DECLARE_INTEGRAL_WITH_CV(bool)
+    EASTL_TMP_DECLARE_INTEGRAL_WITH_CV(char)
+    
     #ifndef EA_WCHAR_T_NON_NATIVE // If wchar_t is a native type instead of simply a define to an existing type...
-        template <> struct is_integral<wchar_t>         : public true_type{};
-        template <> struct is_integral<const wchar_t>   : public true_type{};
+        EASTL_TMP_DECLARE_INTEGRAL_WITH_CV(wchar_t)
     #endif
+    
+    #undef EASTL_TMP_DECLARE_INTEGRAL_WITH_CV
+
 
     ///////////////////////////////////////////////////////////////////////
     // is_floating_point
@@ -122,15 +118,18 @@ namespace eastl
     //
     ///////////////////////////////////////////////////////////////////////
     template <typename T> struct is_floating_point : public false_type{};
-
-    // To do: Need to define volatile and const volatile versions of these.
-    template <> struct is_floating_point<float>             : public true_type{};
-    template <> struct is_floating_point<const float>       : public true_type{};
-    template <> struct is_floating_point<double>            : public true_type{};
-    template <> struct is_floating_point<const double>      : public true_type{};
-    template <> struct is_floating_point<long double>       : public true_type{};
-    template <> struct is_floating_point<const long double> : public true_type{};
-
+    
+    #define EASTL_TMP_DECLARE_FLOATING_POINT_WITH_CV(T)\
+        template <> struct is_floating_point<T>                : public true_type{};\
+        template <> struct is_floating_point<T const>          : public true_type{};\
+        template <> struct is_floating_point<T volatile>       : public true_type{};\
+        template <> struct is_floating_point<T const volatile> : public true_type{};
+    
+    EASTL_TMP_DECLARE_FLOATING_POINT_WITH_CV(float)
+    EASTL_TMP_DECLARE_FLOATING_POINT_WITH_CV(double)
+    EASTL_TMP_DECLARE_FLOATING_POINT_WITH_CV(long double)
+    
+    #undef EASTL_TMP_DECLARE_FLOATING_POINT_WITH_CV
 
 
     ///////////////////////////////////////////////////////////////////////

--- a/include/EASTL/internal/type_properties.h
+++ b/include/EASTL/internal/type_properties.h
@@ -106,29 +106,30 @@ namespace eastl
     // set a given class to be identified as a signed type.
     ///////////////////////////////////////////////////////////////////////
     template <typename T> struct is_signed : public false_type{};
-
-    template <> struct is_signed<signed char>              : public true_type{};
-    template <> struct is_signed<const signed char>        : public true_type{};
-    template <> struct is_signed<signed short>             : public true_type{};
-    template <> struct is_signed<const signed short>       : public true_type{};
-    template <> struct is_signed<signed int>               : public true_type{};
-    template <> struct is_signed<const signed int>         : public true_type{};
-    template <> struct is_signed<signed long>              : public true_type{};
-    template <> struct is_signed<const signed long>        : public true_type{};
-    template <> struct is_signed<signed long long>         : public true_type{};
-    template <> struct is_signed<const signed long long>   : public true_type{};
-
+    
+    #define EASTL_TMP_DECLARE_SIGNED_WITH_CV(T)\
+        template <> struct is_signed<T>                : public true_type{};\
+        template <> struct is_signed<T const>          : public true_type{};\
+        template <> struct is_signed<T volatile>       : public true_type{};\
+        template <> struct is_signed<T const volatile> : public true_type{};
+    
+    EASTL_TMP_DECLARE_SIGNED_WITH_CV(signed char)
+    EASTL_TMP_DECLARE_SIGNED_WITH_CV(signed short)
+    EASTL_TMP_DECLARE_SIGNED_WITH_CV(signed int)
+    EASTL_TMP_DECLARE_SIGNED_WITH_CV(signed long)
+    EASTL_TMP_DECLARE_SIGNED_WITH_CV(signed long long)
+    
     #if (CHAR_MAX == SCHAR_MAX)
-        template <> struct is_signed<char>            : public true_type{};
-        template <> struct is_signed<const char>      : public true_type{};
+        EASTL_TMP_DECLARE_SIGNED_WITH_CV(char)
     #endif
     #ifndef EA_WCHAR_T_NON_NATIVE // If wchar_t is a native type instead of simply a define to an existing type...
         #if defined(__WCHAR_MAX__) && ((__WCHAR_MAX__ == 2147483647) || (__WCHAR_MAX__ == 32767)) // GCC defines __WCHAR_MAX__ for most platforms.
-            template <> struct is_signed<wchar_t>         : public true_type{};
-            template <> struct is_signed<const wchar_t>   : public true_type{};
+            EASTL_TMP_DECLARE_SIGNED_WITH_CV(wchar_t)
         #endif
     #endif
-
+    
+    #undef EASTL_TMP_DECLARE_SIGNED_WITH_CV
+    
     #define EASTL_DECLARE_SIGNED(T) namespace eastl{ template <> struct is_signed<T> : public true_type{}; template <> struct is_signed<const T> : public true_type{}; }
 
 
@@ -150,29 +151,30 @@ namespace eastl
     // set a given class to be identified as an unsigned type.
     ///////////////////////////////////////////////////////////////////////
     template <typename T> struct is_unsigned : public false_type{};
-
-    template <> struct is_unsigned<unsigned char>              : public true_type{};
-    template <> struct is_unsigned<const unsigned char>        : public true_type{};
-    template <> struct is_unsigned<unsigned short>             : public true_type{};
-    template <> struct is_unsigned<const unsigned short>       : public true_type{};
-    template <> struct is_unsigned<unsigned int>               : public true_type{};
-    template <> struct is_unsigned<const unsigned int>         : public true_type{};
-    template <> struct is_unsigned<unsigned long>              : public true_type{};
-    template <> struct is_unsigned<const unsigned long>        : public true_type{};
-    template <> struct is_unsigned<unsigned long long>         : public true_type{};
-    template <> struct is_unsigned<const unsigned long long>   : public true_type{};
-
+    
+    #define EASTL_TMP_DECLARE_UNSIGNED_WITH_CV(T)\
+        template <> struct is_unsigned<T>                : public true_type{};\
+        template <> struct is_unsigned<T const>          : public true_type{};\
+        template <> struct is_unsigned<T volatile>       : public true_type{};\
+        template <> struct is_unsigned<T const volatile> : public true_type{};
+    
+    EASTL_TMP_DECLARE_UNSIGNED_WITH_CV(unsigned char)
+    EASTL_TMP_DECLARE_UNSIGNED_WITH_CV(unsigned short)
+    EASTL_TMP_DECLARE_UNSIGNED_WITH_CV(unsigned int)
+    EASTL_TMP_DECLARE_UNSIGNED_WITH_CV(unsigned long)
+    EASTL_TMP_DECLARE_UNSIGNED_WITH_CV(unsigned long long)
+    
     #if (CHAR_MAX == UCHAR_MAX)
-        template <> struct is_unsigned<char>            : public true_type{};
-        template <> struct is_unsigned<const char>      : public true_type{};
+        EASTL_TMP_DECLARE_UNSIGNED_WITH_CV(char)
     #endif
     #ifndef EA_WCHAR_T_NON_NATIVE // If wchar_t is a native type instead of simply a define to an existing type...
         #if defined(_MSC_VER) || (defined(__WCHAR_MAX__) && ((__WCHAR_MAX__ == 4294967295U) || (__WCHAR_MAX__ == 65535))) // GCC defines __WCHAR_MAX__ for most platforms.
-            template <> struct is_unsigned<wchar_t>         : public true_type{};
-            template <> struct is_unsigned<const wchar_t>   : public true_type{};
+            EASTL_TMP_DECLARE_UNSIGNED_WITH_CV(wchar_t)
         #endif
     #endif
-
+    
+    #undef EASTL_TMP_DECLARE_UNSIGNED_WITH_CV
+    
     #define EASTL_DECLARE_UNSIGNED(T) namespace eastl{ template <> struct is_unsigned<T> : public true_type{}; template <> struct is_unsigned<const T> : public true_type{}; }
 
 


### PR DESCRIPTION
- FIX: "// To do: Need to define volatile and const volatile versions of these."
- added is_integral and is_floating_point specialization for volatile and const volatile types
  FIX:
- added is_signed and is_unsigned specialization for volatile and const volatile types
