### PR TITLE
Fixed compilation of move assginment operator.

### DIFF
--- a/include/EASTL/vector.h
+++ b/include/EASTL/vector.h
@@ -545,7 +545,8 @@ namespace eastl
     inline vector<T, Allocator>& vector<T, Allocator>::operator =(vector<T, Allocator>&& x)
     {
       if(&x != this) {
-        base_type::~VectorBase();
+        DoDestroyValues(mpBegin, mpEnd);
+        DoFree(mpBegin, (size_type)(mpCapacity - mpBegin));
 
         mpBegin = NULL; 
         mpEnd = NULL;

--- a/include/EASTL/vector.h
+++ b/include/EASTL/vector.h
@@ -545,7 +545,7 @@ namespace eastl
     inline vector<T, Allocator>& vector<T, Allocator>::operator =(vector<T, Allocator>&& x)
     {
       if(&x != this) {
-        this->~VectorBase();
+        base_type::~VectorBase();
 
         mpBegin = NULL; 
         mpEnd = NULL;


### PR DESCRIPTION
Hi,

just run into a small compiler error trying to use the 'move assignment operator' in VS2012 like this:

eastl::vector< int > x;
x = eastl::vector< int >(5, 42);
